### PR TITLE
Add lint target default.json

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
         run: yarn
 
       - name: Test
-        run: yarn renovate-config-validator
+        run: yarn renovate-config-validator default.json renovate.json


### PR DESCRIPTION
Previously, default.json was excluded from lint. This was not the intent and will be corrected.