### PR TITLE
Enable lockFileMaintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,9 @@
   "pin": {
     "automerge": true
   },
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "cargo": {
     "packageRules": [
       {


### PR DESCRIPTION
Enable Renovate's lockFileMaintenance.
In the past, poetry.lock, yarn.lock, and Cargo.lock have not been updated when I wanted them to be updated.
