### PR TITLE
Manage Python boto3 related packages together

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,5 +35,17 @@
         ]
       }
     ]
+  },
+  "python": {
+    "packageRules": [
+      {
+        "groupName": "boto3",
+        "matchPackageNames": [
+          "boto3",
+          "botocore",
+          "boto3-stubs"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Boto3 related packages are likely to be released together.
Configure renovate PR to be one.
Note: boto3-stubs is derived from https://github.com/youtype/mypy_boto3_builder and is not completely linked to the boto3 released by AWS.

### Example

The following is an example of when these two were updated at the same time in the bamboo-crawler project.

<img width="1127" alt="screen-shot" src="https://user-images.githubusercontent.com/2596972/225830526-feef4910-34ba-4758-b31e-3db351d4453c.png">

https://github.com/kitsuyui/bamboo-crawler/pull/399
https://github.com/kitsuyui/bamboo-crawler/pull/400

