### PR TITLE
Manage Rust clap related packages together

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,6 +33,14 @@
           "pyo3-macros",
           "pyo3-macros-backend"
         ]
+      },
+      {
+        "groupName": "clap",
+        "matchPackageNames": [
+          "clap",
+          "clap_complete",
+          "clap_derive"
+        ]
       }
     ]
   },


### PR DESCRIPTION
clap, clap_complete, clap_derive are likely to be released together.
Configure renovate PR to be one.

 ### Example

The following is an example of when these two were updated at the same time in the mure project.

https://github.com/kitsuyui/mure/pull/150
https://github.com/kitsuyui/mure/pull/151

<img width="1229" alt="screenshot" src="https://user-images.githubusercontent.com/2596972/226088366-7c31f9a1-6b54-49d1-9406-817a0e717dad.png">
