### PR TITLE
Enable auto-merge for renovate itself

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
         run: yarn
 
       - name: Test
-        run: yarn renovate-config-validator default.json renovate.json
+        run: yarn check

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "check": "renovate-config-validator default.json renovate.json"
+  },
   "devDependencies": {
     "renovate": "35.40.0"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>kitsuyui/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchPackagePatterns": [
+        "renovate"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION

This repository uses renovate-config-validator, which depends on renovate.
Since renovate is updated quite frequently and has a certain quality, minor and patch are enabled for auto-merge.

## chore: Check configuration files with yarn check subcommand

It's long to type yarn renovate-config-validator.
Enable to check with yarn check.
