### PR TITLE
Disable Renovate automerge in GitHub Actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,6 @@
     "github>kitsuyui/renovate-config:npm.json5",
     "github>kitsuyui/renovate-config:python.json5",
     "github>kitsuyui/renovate-config:cargo.json5",
-    "github>kitsuyui/renovate-config:gha.json5",
     "github>kitsuyui/renovate-config:pin.json5",
     "github>kitsuyui/renovate-config:lockfile.json5"
   ],


### PR DESCRIPTION
Currently, it doesn't work well for some reason.
