### PR TITLE
Enable git submodules to be updated by Renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,9 @@
     "github>kitsuyui/renovate-config:pin.json5",
     "github>kitsuyui/renovate-config:lockfile.json5"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "timezone": "Asia/Tokyo",
   "schedule": [
     "before 9am every weekday",


### PR DESCRIPTION
This PR enables git submodules to be updated by Renovate.
https://docs.renovatebot.com/modules/manager/git-submodules/
