### PR TITLE
Migrate coverage reporting to octocov

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -1,0 +1,40 @@
+name: octocov
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  octocov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Installation
+        run: pnpm install
+
+      - name: Test
+        run: pnpm run validate:renovate
+
+      - name: Report coverage with octocov
+        uses: k1LoW/octocov-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config: .octocov.yml

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,10 @@
+# https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # renovate-config
 
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/renovate-config/coverage.svg)
+
 This repository contains common configuration for renovate.
 You can use this common configuration by specifying this repository as `extends` in your renovate.json.
 


### PR DESCRIPTION
Add octocov configuration and workflow, and update README coverage badge.