### PR TITLE
Add minimum release age policy for npm and PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,34 @@ For example, the following things.
 
 If you configure these things in each project, you will have to configure the same thing in multiple projects.
 
+### Minimum release age policy
+
+This preset adds a short quarantine window before newly published releases are proposed by Renovate.
+
+- `npm`: `3 days`
+- `pypi`: `2 days`
+- `cargo`: `3 days`
+- `github-actions`: `3 days`
+
+The main reference is Renovate's `minimumReleaseAge` feature:
+
+- https://docs.renovatebot.com/key-concepts/minimum-release-age/
+
+The current defaults are chosen with the following official references in mind:
+
+- `npm`: keep `3 days` to align with Renovate's npm security preset and npm's 72 hour unpublish window
+  - https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
+  - https://docs.npmjs.com/policies/unpublish/
+- `pypi`: use `2 days` because PyPI states that security reports are acknowledged within 48 hours
+  - https://pypi.org/security/
+  - https://docs.pypi.org/project-management/yanking/
+  - https://blog.pypi.org/posts/2023-12-13-2fa-enforcement/
+- `cargo`: use the default `3 days` because crates.io documents removal/advisory processes, but this repository does not rely on a fixed public review SLA
+  - https://blog.rust-lang.org/2026/02/13/crates.io-malicious-crate-update/
+  - https://blog.rust-lang.org/2022/05/10/malicious-crate-rustdecimal/
+- `github-actions`: use the default `3 days` because GitHub documents governance controls, but this repository does not rely on a fixed public Marketplace review SLA
+  - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+
 ### Auto merge policy
 
 I only enable auto merge for the following rules.

--- a/cargo.json5
+++ b/cargo.json5
@@ -2,6 +2,26 @@
   cargo: {
     packageRules: [
       {
+        /**
+         * Keep the default quarantine window for crates.io updates.
+         *
+         * Docs:
+         * - Renovate Minimum Release Age
+         *   https://docs.renovatebot.com/key-concepts/minimum-release-age/
+         * - crates.io now publishes RustSec advisories when malicious crates are removed
+         *   https://blog.rust-lang.org/2026/02/13/crates.io-malicious-crate-update/
+         * - crates.io removes malicious crates when the Rust security team is made aware of them
+         *   https://blog.rust-lang.org/2022/05/10/malicious-crate-rustdecimal/
+         *
+         * Inference:
+         * - crates.io documents response mechanisms, but no fixed public review/removal SLA is cited here.
+         *   Keep the default 3 day quarantine window.
+         */
+        matchDatasources: ["crate"],
+        internalChecksFilter: "strict",
+        minimumReleaseAge: "3 days",
+      },
+      {
         groupName: "serde",
         matchPackageNames: [
           "serde",

--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     "github>kitsuyui/renovate-config:npm.json5",
     "github>kitsuyui/renovate-config:python.json5",
     "github>kitsuyui/renovate-config:cargo.json5",
+    "github>kitsuyui/renovate-config:gha.json5",
     "github>kitsuyui/renovate-config:pin.json5",
     "github>kitsuyui/renovate-config:lockfile.json5"
   ],

--- a/gha.json5
+++ b/gha.json5
@@ -1,7 +1,27 @@
 {
   // GitHub Actions
-  github-actions: {
+  "github-actions": {
     packageRules: [ 
+      {
+        /**
+         * Keep the default quarantine window for GitHub Actions updates.
+         *
+         * Docs:
+         * - Renovate Minimum Release Age
+         *   https://docs.renovatebot.com/key-concepts/minimum-release-age/
+         * - GitHub lets repositories and organizations restrict which actions can run
+         *   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+         * - GitHub can require actions to be pinned to a full-length commit SHA
+         *   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+         *
+         * Inference:
+         * - GitHub documents governance controls, but no fixed public Marketplace malware review SLA is cited here.
+         *   Keep the default 3 day quarantine window.
+         */
+        matchDatasources: ["github-tags"],
+        internalChecksFilter: "strict",
+        minimumReleaseAge: "3 days",
+      },
       {
         matchPackagePatterns: ["^actions/checkout$"],
         /**

--- a/npm.json5
+++ b/npm.json5
@@ -2,6 +2,22 @@
   npm: {
     packageRules: [
       {
+        /**
+         * Delay npm updates for a short quarantine window.
+         *
+         * Docs:
+         * - Renovate Minimum Release Age
+         *   https://docs.renovatebot.com/key-concepts/minimum-release-age/
+         * - Renovate security preset for npm uses 3 days
+         *   https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
+         * - npm unpublish policy allows newly created packages to be unpublished within 72 hours
+         *   https://docs.npmjs.com/policies/unpublish/
+         */
+        matchDatasources: ["npm"],
+        internalChecksFilter: "strict",
+        minimumReleaseAge: "3 days",
+      },
+      {
         groupName: "swc",
         matchPackageNames: ["@swc/core", "@swc/jest"],
         /**

--- a/python.json5
+++ b/python.json5
@@ -3,7 +3,7 @@
     packageRules: [
       {
         /**
-         * Delay PyPI updates briefly, but shorter than npm.
+         * Delay PyPI updates briefly, but keep a 48 hour quarantine window.
          *
          * Docs:
          * - Renovate Minimum Release Age
@@ -17,7 +17,7 @@
          */
         matchDatasources: ["pypi"],
         internalChecksFilter: "strict",
-        minimumReleaseAge: "1 day",
+        minimumReleaseAge: "2 days",
       },
       {
         groupName: "boto3",

--- a/python.json5
+++ b/python.json5
@@ -2,6 +2,24 @@
   python: {
     packageRules: [
       {
+        /**
+         * Delay PyPI updates briefly, but shorter than npm.
+         *
+         * Docs:
+         * - Renovate Minimum Release Age
+         *   https://docs.renovatebot.com/key-concepts/minimum-release-age/
+         * - PyPI supports yanking as a non-destructive alternative to deletion
+         *   https://docs.pypi.org/project-management/yanking/
+         * - PyPI requires 2FA for all users since 2024-01-01
+         *   https://blog.pypi.org/posts/2023-12-13-2fa-enforcement/
+         * - PyPI security reports are acknowledged within 48 hours
+         *   https://pypi.org/security/
+         */
+        matchDatasources: ["pypi"],
+        internalChecksFilter: "strict",
+        minimumReleaseAge: "1 day",
+      },
+      {
         groupName: "boto3",
         matchPackageNames: ["boto3", "botocore", "boto3-stubs"],
       },


### PR DESCRIPTION
## Summary
- add a 3 day `minimumReleaseAge` rule for npm packages
- add a 1 day `minimumReleaseAge` rule for PyPI packages
- record the supporting official documentation directly in the JSON5 comments

## Rationale
- npm uses `3 days` to align with Renovate's npm security preset and npm's 72 hour unpublish window
- PyPI uses `1 day` to keep the delay shorter while still adding a quarantine window; the comment cites PyPI's yanking model, 2FA enforcement, and security response guidance

## Validation
- `node -e "const fs=require('fs'); const vm=require('vm'); for (const f of ['npm.json5','python.json5']) { vm.runInNewContext('(' + fs.readFileSync(f,'utf8') + ' )'); console.log(f + ' : ok'); }"`
- `npm_config_legacy_peer_deps=true npx --yes --package renovate renovate-config-validator default.json renovate.json5`
- `npm_config_legacy_peer_deps=true npx --yes --package renovate renovate-config-validator npm.json5 python.json5`
