### PR TITLE
fix: update renovate package rule matcher

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,8 +12,8 @@
       "matchDepTypes": [
         "devDependencies"
       ],
-      "matchPackagePatterns": [
-        "renovate"
+      "matchPackageNames": [
+        "/renovate/"
       ],
       "automerge": true
     }


### PR DESCRIPTION
## Summary
- replace the deprecated renovate package matcher with the current matcher syntax
- keep the existing automerge intent for renovate updates

## Testing
- pnpm run validate:renovate
