### PR TITLE
Validate all Renovate preset fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "validate:renovate": "renovate-config-validator default.json renovate.json5"
+    "validate:renovate": "renovate-config-validator default.json *.json5"
   },
   "devDependencies": {
     "renovate": "43.29.2"


### PR DESCRIPTION
## Summary

- Expand the Renovate validation script to check `default.json` and every `*.json5` preset file.
- Add CI coverage for preset fragments such as `npm.json5`, `python.json5`, and `cargo.json5`.

## Validation

- `bun install --frozen-lockfile`
- `bun run validate:renovate`
