### PR TITLE
Pin GitHub Actions digests

### DIFF
--- a/gha.json5
+++ b/gha.json5
@@ -1,5 +1,8 @@
 {
   // GitHub Actions
+  extends: [
+    "helpers:pinGitHubActionDigests",
+  ],
   "github-actions": {
     packageRules: [ 
       {


### PR DESCRIPTION
## Summary
- Enable Renovate GitHub Actions digest pinning through `helpers:pinGitHubActionDigests`.
- Keep the existing GitHub Actions update quarantine and automerge rules unchanged.

## Changed files
- `gha.json5`

## Validation
- `bun run validate:renovate`
- `git diff --check`
