### PR TITLE
Pin write-capable reusable workflow

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary

- Pin the write-capable reusable workflow reference to a specific commit SHA.
- Keep the existing schedule and permissions unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gitignore-in.yml"); puts "yaml ok"'
- actionlint .github/workflows/gitignore-in.yml