### PR TITLE
Pin workflow action refs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@b48db82eb82c1f469430bb981812e58aca61d5b5


### PR DESCRIPTION
## Summary
- Pin GitHub Actions workflow references to immutable commit SHAs.
- Keep version comments on action refs where the original tag is useful context.

## Verification
- actionlint .github/workflows/*.yml
- git diff --check origin/main...HEAD
- Confirmed each pinned action or reusable workflow ref resolves through the GitHub API.
