### PR TITLE
Declare lint workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Test renovate.json configuration
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate


### PR DESCRIPTION
## Summary
- Declare read-only `GITHUB_TOKEN` permissions for the lint workflow.
- Keep the workflow scoped to repository contents access for checkout and validation.

## Verification
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `bun run validate:renovate`
