### PR TITLE
Auto-merge kitsuyui/gh-actions-workflows updates

### DIFF
--- a/gha.json5
+++ b/gha.json5
@@ -57,6 +57,14 @@
          */
         automerge: true,
       },
+      {
+        matchPackagePatterns: ["^kitsuyui/gh-actions-workflows$"],
+        /**
+         * Automerge is enabled.
+         * Reason: I am the author.
+         */
+        automerge: true,
+      },
     ],
   },
 }


### PR DESCRIPTION
Author-owned, mirrors the existing `kitsuyui/happy-commit` rule.