### PR TITLE
fix: extend GHA quarantine to github-releases datasource

### DIFF
--- a/gha.json5
+++ b/gha.json5
@@ -21,7 +21,7 @@
          * - GitHub documents governance controls, but no fixed public Marketplace malware review SLA is cited here.
          *   Keep the default 3 day quarantine window.
          */
-        matchDatasources: ["github-tags"],
+        matchDatasources: ["github-tags", "github-releases"],
         internalChecksFilter: "strict",
         minimumReleaseAge: "3 days",
       },


### PR DESCRIPTION
## Summary

`gha.json5` applied the 3-day `minimumReleaseAge` quarantine only to the
`github-tags` datasource. Renovate can also fetch GitHub Actions updates via
the `github-releases` datasource, which was not covered by the rule, allowing
those updates to automerge without the quarantine window.

## Changes

- `gha.json5`: extend `matchDatasources` from `["github-tags"]` to
  `["github-tags", "github-releases"]` in the quarantine `packageRule`.

## Verification

```sh
bun install --frozen-lockfile
bun run validate:renovate  # Config validated successfully
```

## Trade-offs

Adding `github-releases` is the minimal fix. The quarantine semantics are
unchanged; only the datasource coverage is widened. No behaviour change for
actions that Renovate fetches exclusively via `github-tags`.
