### PR TITLE
docs: document live-update semantics and SHA pinning option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ For example, the following things.
 
 If you configure these things in each project, you will have to configure the same thing in multiple projects.
 
+### Versioning and live updates
+
+This repository has **no versioned releases**. All sub-preset references in
+`default.json` (`github>kitsuyui/renovate-config:<file>`) point to the default
+branch without SHA pinning. This is intentional: changes take effect
+immediately for all consumers.
+
+If you need a stable, reproducible configuration, pin the reference in your
+own config file using the commit SHA:
+
+```json
+{
+  "extends": [
+    "github>kitsuyui/renovate-config@<commit-sha>"
+  ]
+}
+```
+
+See the [Renovate docs on presets](https://docs.renovatebot.com/config-presets/)
+for details on how SHA pinning works for `github>` references.
+
 ### Minimum release age policy
 
 This repository keeps only the applied configuration values.


### PR DESCRIPTION
## Summary

`default.json` references six sub-preset files via
`github>kitsuyui/renovate-config:<file>` without SHA pinning. This is
intentional — the repository has no versioned releases and is designed so
that changes propagate immediately to all consumers. However, the design was
undocumented, which could mislead consumers into thinking SHA pinning is
unnecessary in their own configs, or leave them unaware that the same extends
path can resolve to different content across Renovate runs.

## Changes

- `README.md`: add a **Versioning and live updates** section that:
  - states explicitly that no versioned releases exist and changes take effect
    immediately
  - shows how consumers can optionally pin to a commit SHA for reproducibility

## Verification

```sh
bun run validate:renovate  # Config validated successfully (README not parsed)
git diff --check            # no whitespace errors
```

## Trade-offs

The documentation change does not alter any Renovate config behaviour. It
makes the live-update contract visible so consumers can make an informed
choice about whether to pin or not.
