### PR TITLE
fix: tighten Renovate package matchers

### DIFF
--- a/cargo.json5
+++ b/cargo.json5
@@ -23,12 +23,6 @@
       },
       {
         groupName: "serde",
-        matchPackageNames: [
-          "serde",
-          "serde_derive",
-          "serde_json",
-          "serde_yaml",
-        ],
         matchPackagePatterns: ["^serde"],
       },
       {

--- a/npm.json5
+++ b/npm.json5
@@ -30,11 +30,7 @@
         automerge: true,
       },
       {
-        matchPackagePatterns: [
-          "^@types/node$",
-          "^@types/react$",
-          "^@types/react-dom$",
-        ],
+        matchPackageNames: ["@types/node", "@types/react", "@types/react-dom"],
         /**
          * Automerge is enabled.
          * Reason: Package Health
@@ -78,16 +74,17 @@
          automerge: true,
       },
       {
-        matchPackagePatterns: ["^eslint$"],
+        matchPackageNames: ["eslint", "@eslint/js"],
         /**
          * Automerge is enabled.
          * Reason: Package Health
          * https://snyk.io/advisor/npm-package/eslint
+         * https://snyk.io/advisor/npm-package/@eslint/js
          */
         automerge: true,
       },
       {
-        matchPackagePatterns: ["^prettier$"],
+        matchPackageNames: ["prettier"],
         /**
          * Automerge is enabled.
          * Reason: Package Health


### PR DESCRIPTION
Summary

- Tighten the Cargo `serde` group by keeping the `^serde` package pattern and removing the redundant explicit package name list.
- Replace regex-style package matching with exact package names for `@types/*` and `prettier`, and align the eslint automerge rule to exact package names with the added `@eslint/js` Snyk reference.

Tests

- implement-validator overall: pass
- bun install --frozen-lockfile: pass/no changes
- bunx --bun json5 --validate cargo.json5: pass
- bunx --bun json5 --validate npm.json5: pass
- bun run validate:renovate: pass (existing migration warnings remain)
- bunx --bun typos cargo.json5 npm.json5: pass
- git diff --check: pass
- read-only matcher audit script: pass, no exact regex or duplicate name/pattern matcher issues
