### PR TITLE
fix: restrict author-package automerge to minor and patch updates

### DIFF
--- a/cargo.json5
+++ b/cargo.json5
@@ -54,8 +54,10 @@
         /**
          * Automerge is enabled.
          * Reason: I am the author
+         * Major version bumps are excluded to require explicit review.
          */
         automerge: true,
+        matchUpdateTypes: ["minor", "patch"],
       },
     ],
   },

--- a/gha.json5
+++ b/gha.json5
@@ -54,16 +54,20 @@
         /**
          * Automerge is enabled.
          * Reason: I am the author.
+         * Major version bumps are excluded to require explicit review.
          */
         automerge: true,
+        matchUpdateTypes: ["minor", "patch"],
       },
       {
         matchPackagePatterns: ["^kitsuyui/gh-actions-workflows$"],
         /**
          * Automerge is enabled.
          * Reason: I am the author.
+         * Major version bumps are excluded to require explicit review.
          */
         automerge: true,
+        matchUpdateTypes: ["minor", "patch"],
       },
     ],
   },

--- a/npm.json5
+++ b/npm.json5
@@ -101,8 +101,10 @@
         /**
          * Automerge is enabled.
          * Reason: I am the author
+         * Major version bumps are excluded to require explicit review.
          */
         automerge: true,
+        matchUpdateTypes: ["minor", "patch"],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Author-owned package automerge rules in `npm.json5`, `cargo.json5`, and `gha.json5`
were missing `matchUpdateTypes`, which caused major version bumps to be auto-merged
without review. This PR adds `matchUpdateTypes: ["minor", "patch"]` to all four
affected rules, bringing them in line with the existing `renovate.json5` self-update
rule that already excludes major updates.

## Changes

- `npm.json5`: `kitsuyui-react-packages` group — add `matchUpdateTypes`
- `cargo.json5`: `rust-codecov` pattern — add `matchUpdateTypes`
- `gha.json5`: `kitsuyui/happy-commit` pattern — add `matchUpdateTypes`
- `gha.json5`: `kitsuyui/gh-actions-workflows` pattern — add `matchUpdateTypes`

## Rationale

Major version bumps can introduce breaking API changes even for packages authored
by the repo owner. The "I am the author" reason justifies automerge for routine
minor/patch updates, but major bumps still warrant explicit review by consumers
of this preset. The `renovate.json5` self-update rule already follows this pattern.

## Verification

`bun run validate:renovate` passes with no errors. The migration warnings shown
are pre-existing (`matchPackagePatterns` deprecation) and unrelated to this change.
