### PR TITLE
fix: write .gitignore atomically via temp file

### DIFF
--- a/.gitignore.in
+++ b/.gitignore.in
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "${0%/*}" && exec > .gitignore
-gi() { curl -L -s https://www.gitignore.io/api/"$*"; }
-# `gibo list' and `gi list'
-gibo dump Linux
-gibo dump Windows
-gibo dump macOS
-gibo dump Node
+cd "${0%/*}"
+{
+  gibo dump Linux
+  gibo dump Windows
+  gibo dump macOS
+  gibo dump Node
+} > .gitignore.tmp
+[ -s .gitignore.tmp ] || { rm -f .gitignore.tmp; exit 1; }
+mv .gitignore.tmp .gitignore


### PR DESCRIPTION
## Summary

`.gitignore.in` previously used `exec > .gitignore` to redirect stdout directly to the target file, truncating it immediately before any content was written. If `gibo dump` failed mid-run (network error, CI timeout, etc.) the file would be left empty or partial.

This PR rewrites the script to use an atomic write pattern:

1. Collect all `gibo dump` output into `.gitignore.tmp`
2. Verify the temp file is non-empty (guards against `gibo` returning exit 0 with empty output on network failure)
3. Rename `.gitignore.tmp` → `.gitignore` atomically

Additionally removes the unused `gi()` helper function, which was defined but never called.

## Changes

- `.gitignore.in`: replace direct `exec > .gitignore` redirect with temp-file + non-empty check + `mv`; remove dead `gi()` function

## Verification

- `shellcheck .gitignore.in`: 0 findings
- `bun run validate:renovate`: Config validated successfully
