### PR TITLE
fix: use exact package name match for renovate automerge rule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,7 @@
         "devDependencies"
       ],
       "matchPackageNames": [
-        "/renovate/"
+        "renovate"
       ],
       "automerge": true
     }


### PR DESCRIPTION
## Summary

`renovate.json5` has a `packageRules` entry that uses `/renovate/` as a `matchPackageNames` pattern with `automerge: true`. In Renovate, the `/pattern/` syntax is a partial-match regex, so this would match any package whose name contains the string "renovate" (e.g. `@renovate/config-validator`, `renovate-config-starter`) — broader than the intended target.

This PR changes the pattern to the exact string `"renovate"`, which matches only the package named exactly `renovate`.

## Change

```diff
-        "/renovate/"
+        "renovate"
```

## Verification

- `bun run validate:renovate` passes
- `bun test` passes (22/22)

## Trade-offs

The exact string match is the simplest fix. If a regex is needed in the future (e.g. to cover a family of packages), it should use anchors like `/^renovate$/` to make the scope explicit.
