### PR TITLE
docs: remove hardcoded minimumReleaseAge values from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,8 @@ The source-of-truth document for the policy rationale and official ecosystem ref
 
 - https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies
 
-Current values in this preset:
-
-- `npm`: `3 days`
-- `pypi`: `2 days`
-- `cargo`: `3 days`
-- `github-actions`: `3 days`
+Current values are defined directly in each preset file (`npm.json5`, `python.json5`,
+`cargo.json5`, `gha.json5`) in the `minimumReleaseAge` field.
 
 ### Auto merge policy
 


### PR DESCRIPTION
## Summary

The "Minimum release age policy" section in README.md listed four hardcoded values:

- `npm`: `3 days`
- `pypi`: `2 days`
- `cargo`: `3 days`
- `github-actions`: `3 days`

These values are already defined in the respective preset files (`npm.json5`,
`python.json5`, `cargo.json5`, `gha.json5`) under the `minimumReleaseAge` field.
Maintaining both copies creates a drift risk: if a preset file is updated,
the README may silently fall out of sync with no CI check to catch it.

## Change

Replace the hardcoded list with a pointer to the authoritative preset files.
Readers who want the current values can look at the `minimumReleaseAge` field
in each JSON5 file directly.

## Verification

- `bun run validate:renovate` — passed
- `bun test` — 22 tests pass
