### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ I only enable auto merge for the following rules.
   - Community ... Code of conducts, number of maintainers, number of contributors, code review, code coverage, etc.
   - Documentation ... README, CONTRIBUTING, etc.
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the hooks once after cloning:
+
+```sh
+lefthook install
+```
+
+### Git hooks
+
+| Hook | Jobs | Command |
+| --- | --- | --- |
+| pre-commit | validate-renovate | `bun run validate:renovate` |
+| pre-push | validate-renovate | `bun run validate:renovate` |
+| pre-push | test | `bun test` |
+
+The pre-commit hook validates all Renovate config files against the schema so you get
+feedback before the commit is recorded.
+The pre-push hook re-runs validation and the full test suite before pushing.
+
+CI (`lint.yml`) runs the same commands on every pull request — the hooks bring that
+feedback earlier in the development cycle without replacing CI.
+
 ## License
 
 I don't think that there is any right in this repository because this repository contains only configuration for Renovate application.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: validate-renovate
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run validate:renovate
+
+pre-push:
+  jobs:
+    - name: validate-renovate
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run validate:renovate
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to run the same checks as `lint.yml` CI locally via git hooks
- pre-commit: runs `bun run validate:renovate` (schema validation — fast feedback before commit)
- pre-push: runs `bun run validate:renovate` + `bun test` (full suite before the branch reaches CI)
- Document `lefthook install` and the hook behaviour in a new `## Development` section in `README.md`
- CI (`lint.yml`) is kept entirely unchanged

## Files changed

- `lefthook.yml` — new file defining pre-commit and pre-push jobs
- `README.md` — new `## Development` section inserted before `## License`
