### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub Issue to report a security vulnerability.
+
+Use [GitHub's private vulnerability reporting](https://github.com/kitsuyui/renovate-config/security/advisories/new) to submit a report. This keeps the details confidential until a fix is ready.
+
+Include the following in your report:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a minimal proof-of-concept
+- Any relevant version or configuration information
+
+You will receive a response as soon as possible. If the vulnerability is confirmed, a fix will be prepared and a public advisory will be published after the fix is released.


### PR DESCRIPTION
## Summary

Add `SECURITY.md` to provide a clear, private channel for reporting security issues.

- This repository contains Renovate presets with `automerge: true` rules used by downstream repos. Users who discover a misconfiguration with security implications currently have no documented way to report it privately.
- Adds `SECURITY.md` pointing to GitHub's private vulnerability reporting, consistent with [gh-counter](https://github.com/kitsuyui/gh-counter/blob/main/SECURITY.md) and other kitsuyui repositories.

## Changes

- `SECURITY.md`: new file — describes how to report vulnerabilities via GitHub private vulnerability reporting

## Verification

- `bun run validate:renovate` — pass (no config changes)
- `bun test` — 22 tests pass (no logic changes)
- `typos SECURITY.md` — no spelling errors
