### PR TITLE
ci: add optional release workflow for versioned snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate version format
+        run: bash scripts/validate-semver.sh "${{ inputs.version }}"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate schema
+        run: bun run validate:renovate
+
+      - name: Run tests
+        run: bun test
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ inputs.version }}" --generate-notes

--- a/scripts/validate-semver.sh
+++ b/scripts/validate-semver.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+VERSION="${1:?Usage: validate-semver.sh <version>}"
+if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'; then
+  echo "::error::version must match vMAJOR.MINOR.PATCH, got: $VERSION" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered release workflow so the repository can publish optional versioned snapshots without changing the default extends behavior.

- **`scripts/validate-semver.sh`** — validates the version input against `vMAJOR.MINOR.PATCH` before any release steps run
- **`.github/workflows/release.yml`** — the release workflow:
  1. Validates the version tag format via `scripts/validate-semver.sh`
  2. Runs `bun run validate:renovate` to confirm all preset files are still schema-valid
  3. Runs `bun test` to confirm all pattern-matching tests pass
  4. Creates a GitHub Release with auto-generated notes (`gh release create --generate-notes`)

## Motivation

The default extends path (`github>kitsuyui/renovate-config`) resolves to the HEAD of the default branch, and that behavior is intentional and documented in the README. This workflow does not change that default.

However, having no versioned releases also means consumers who want a reproducible, auditable configuration reference have no named anchor other than a raw commit SHA. Adding a manual release workflow gives the maintainer the option to publish a named version at any time—for example, before rolling out a breaking preset change—without forcing a fixed release cadence.

## Verification

- Semver validation is exercised by the workflow gate and can be tested locally: `bash scripts/validate-semver.sh v1.0.0` (pass), `bash scripts/validate-semver.sh 1.0.0` (fail).
- The schema and test steps run the same commands as `lint.yml`, so the release gate and CI gate remain in sync.
- Action refs are pinned to full SHAs, matching the convention already used in `lint.yml`.

## Trade-offs

- Releases are still fully manual (triggered via `workflow_dispatch`); no semantic-release automation is introduced.
- The README's "no versioned releases" disclaimer remains accurate until the first release is actually published.
